### PR TITLE
Minor fixes

### DIFF
--- a/chemtools/conceptual/squareroot.py
+++ b/chemtools/conceptual/squareroot.py
@@ -93,12 +93,13 @@ class SquareRootGlobalTool(BaseGlobalTool):
         check_number_electrons(n_elec, self._n0 - 1, self._n0 + 1)
 
         # Square Root Model goes to infinity as N goes to infinity.
-        output = self._params[0] + self._params[1] * np.sqrt(n_elec) + self._params[2] * n_elec
         if np.isinf(n_elec):
             if self.params[2] > 0.:
                 output = np.inf
             else:
                 output = -np.inf
+        else:
+            output = self._params[0] + self._params[1] * np.sqrt(n_elec) + self._params[2] * n_elec
         return output
 
     @doc_inherit(BaseGlobalTool)

--- a/chemtools/topology/critical_pts.py
+++ b/chemtools/topology/critical_pts.py
@@ -124,7 +124,7 @@ class Topo(object):
         y = np.arange(min_xyz[1] - extra, max_xyz[1] + extra, 0.2)
         z = np.arange(min_xyz[2] - extra, max_xyz[2] + extra, 0.2)
         g = np.meshgrid(x, y, z)
-        return np.vstack(np.ravel(i) for i in g).T
+        return np.stack([i.ravel() for i in g], axis=1)
 
     def add_points(self, points):
         """Add a point to exiting initial guess points.

--- a/chemtools/topology/test/test_critical_pts.py
+++ b/chemtools/topology/test/test_critical_pts.py
@@ -12,11 +12,11 @@ class TestCriticalPoints(TestCase):
     """Test critical point finder class."""
 
     def gauss_func(self, coors, centers=np.zeros(3), alphas=1):
-        """Generate gaussian function value."""
+        # """Generate gaussian function value.
         return np.prod(np.exp((-alphas * (coors - centers) ** 2)), axis=-1)
 
     def gauss_deriv(self, coors, centers=np.zeros(3), alphas=1):
-        """Generate 1st order derivative of gaussian function."""
+        # """Generate 1st order derivative of gaussian function."""
         if coors.ndim > 1:
             func_v = self.gauss_func(coors, centers, alphas)[:, None]
         else:
@@ -24,7 +24,7 @@ class TestCriticalPoints(TestCase):
         return -2 * alphas * (coors - centers) * func_v
 
     def gauss_deriv2(self, coors, centers=np.zeros(3), alphas=1):
-        """Generate 2nd order derivative of gaussian function."""
+        # """Generate 2nd order derivative of gaussian function."""
         diag = (
             -2 * alphas + 4 * alphas ** 2 * (coors - centers) ** 2
         ) * self.gauss_func(coors, centers, alphas)
@@ -41,27 +41,27 @@ class TestCriticalPoints(TestCase):
         return hm
 
     def test_topo(self):
-        """Test properly initiate topo instance."""
+        # """Test properly initiate topo instance."""
         coors = np.array([[1, 1, 1], [-1, -1, -1]])
         pts = np.random.rand(4, 3)
         topo = Topo(coors, self.gauss_func, self.gauss_deriv, self.gauss_deriv2, pts)
         assert isinstance(topo, Topo)
 
     def test_default_cube(self):
-        """Test default cube for points."""
+        # """Test default cube for points."""
         coors = np.array([[1, 1, 1], [-1, -1, -1]])
         topo = Topo(coors, self.gauss_func, self.gauss_deriv, self.gauss_deriv2)
         assert topo._kdtree.data.shape == (60 * 60 * 60, 3)
 
     def test_construct_cage(self):
-        """Test construct cage among target points."""
+        # """Test construct cage among target points."""
         pts = Topo._construct_cage(np.array([0, 0, 0]), 1)
         assert len(pts) == 4
         dis = np.linalg.norm(pts[:] - np.array([0, 0, 0]), axis=-1)
         assert_allclose(dis, np.ones(4) * 4.89898, rtol=1e-5)
 
     def test_get_gradietn(self):
-        """Test get proper gradient."""
+        # """Test get proper gradient."""
         # initiate topo obj.
         coors = np.array([[1, 1, 1], [-1, -1, -1]])
         pts = np.random.rand(4, 3)
@@ -74,7 +74,7 @@ class TestCriticalPoints(TestCase):
         assert_allclose(ref_g, g_pts)
 
     def test_add_critical_points(self):
-        """Test add critical points to class."""
+        # """Test add critical points to class."""
         coors = np.array([[1, 1, 1], [-1, -1, -1]])
         pts = np.random.rand(4, 3)
         topo = Topo(coors, self.gauss_func, self.gauss_deriv, self.gauss_deriv2, pts)
@@ -97,7 +97,7 @@ class TestCriticalPoints(TestCase):
         assert_allclose(topo._crit_cage[0].point, pt.point, atol=1e-10)
 
     def test_is_coors_pt(self):
-        """Test same pts as nuclear position."""
+        # """Test same pts as nuclear position."""
         coors = np.array([[1, 1, 1], [-1, -1, -1]])
         pts = np.random.rand(4, 3)
         topo = Topo(coors, self.gauss_func, self.gauss_deriv, self.gauss_deriv2, pts)
@@ -110,7 +110,7 @@ class TestCriticalPoints(TestCase):
             assert not result
 
     def test_find_one_critical_pt(self):
-        """Test two atoms critical pts."""
+        # """Test two atoms critical pts."""
         atoms = np.array([[-2, -2, -2], [2, 2, 2]])
         alf = 0.3
 
@@ -147,7 +147,7 @@ class TestCriticalPoints(TestCase):
         assert_allclose(tp_ins._found_ct[0], [0, 0, 0], atol=1e-10)
 
     def test_find_triangle_critical_pt(self):
-        """Test three atom ring critical pts."""
+        # """Test three atom ring critical pts."""
         atoms = np.array([[-2, -2, 0], [2, -2, 0], [0, 1, 0]])
         alf = 1
 


### PR DESCRIPTION
- Commented out docstrings of unit tests because they make life hard when trying to find a unit test causing trouble. This is specific for nosetests and the docstrings can be put back when switching to pytest
- Fixed one warning related to NumPy.
- The other warning I got rid off might have been intentional, like some of the other warnings still present. If it was intentional, it should be made more intuitive and it should be tested. Asserting warnings can be done with nosetests (https://stackoverflow.com/questions/3587407/check-that-a-function-raises-a-warning-with-nose-tests) or pytest (https://docs.pytest.org/en/3.0.4/recwarn.html)