### PR TITLE
Try to fix HORTON log issue (again)

### DIFF
--- a/chemtools/__init__.py
+++ b/chemtools/__init__.py
@@ -33,6 +33,7 @@ from chemtools.outputs import *
 import horton
 
 
-horton.log._level = 1
+horton.log.head_banner = ""
+horton.log.foot_banner = ""
 
 __version__ = '0.9.0'


### PR DESCRIPTION
Turns out there is a horton warning that we cannot avoid, which means
that if we set the horton.log to silent, horton will raise RuntimeError.
The next level in log, warning, will still print the banner and the
footer.

Since we cannot fix horton here without being too messy, we'll over
write the header and footer with nothing