### PR TITLE
Convert masked_array to normal array

### DIFF
--- a/chemtools/toolbox/interactions.py
+++ b/chemtools/toolbox/interactions.py
@@ -327,7 +327,8 @@ class ELF(BaseInteraction):
         self._ratio = ked - self._denstool.ked_weizsacker
         self._ratio /= masked_less(self._denstool.ked_thomas_fermi, 1.0e-30)
         # compute elf value & set low density points to zero
-        self._value = self._transform(self._ratio, trans.lower(), trans_k, trans_a)
+        self._value = np.asarray(self._transform(self._ratio, trans.lower(),
+                                                 trans_k, trans_a))
         self._value[self._denstool.density < denscut] = 0.
 
     @classmethod
@@ -498,7 +499,8 @@ class LOL(BaseInteraction):
         # compute elf ratio
         self._ratio = self._denstool.ked_thomas_fermi / masked_less(ked, 1.0e-30)
         # compute elf value & set low density points to zero
-        self._value = self._transform(self._ratio, trans.lower(), trans_k, trans_a)
+        self._value = np.asarray(self._transform(self._ratio, trans.lower(),
+                                                 trans_k, trans_a))
         self._value[self._denstool.density < denscut] = 0
 
     @classmethod


### PR DESCRIPTION
## Description
1. Use asarray function to convert masked_array to normal array
   for consistency

Reason: masked_array doesn't support MaskedArray.tofile() method. It would be more helpful just convert a property array to normal np.array.

## Checks
Please remove the checks that are not applicable to your PR, and replace [ ] with [x] to mark the
checks that are already completed. You can finish the other relevant checks after opening the PR.

- [ x] Each commit addresses one thing.
- [ x] Each commit message is informative and is less than 50 characters.
- [ x] Commits that can be grouped together are squashed.
- [ x] Each unit of code added is tested.
- [ x] Each unit of code added is documented.
- [ x] Commits are rebased onto master.


## Type of Changes
 :art: Improve Format & Structure