### PR TITLE
Adding Critical Points (Vectorized) and Finding Bond Paths

### DIFF
--- a/chemtools/__init__.py
+++ b/chemtools/__init__.py
@@ -30,6 +30,7 @@ from chemtools.conceptual import *
 from chemtools.denstools import *
 from chemtools.utils import *
 from chemtools.outputs import *
+from chemtools.topology import *
 import horton
 
 

--- a/chemtools/topology/__init__.py
+++ b/chemtools/topology/__init__.py
@@ -23,4 +23,6 @@
 """The Scalar Field Topological Analysis Module."""
 
 
-from chemtools.topology import *
+from chemtools.topology.critical import *
+from chemtools.topology.ode import *
+from chemtools.topology.point import *

--- a/chemtools/topology/critical.py
+++ b/chemtools/topology/critical.py
@@ -412,7 +412,7 @@ class Topology(object):
         if not self.poincare_hopf_equation:
             warnings.warn("Poincare–Hopf equation is not satisfied.", RuntimeWarning)
 
-    def find_bond_paths(self, eps_dir=1e-4, tol=1e-14, ss_0=1e-8, max_ss=0.01, maxiter=2000):
+    def find_bond_paths(self, eps_dir=1e-4, tol=1e-8, ss_0=1e-8, max_ss=0.25, maxiter=2000):
         r"""
         Find bond paths of each bond critical point.
 

--- a/chemtools/topology/critical.py
+++ b/chemtools/topology/critical.py
@@ -26,9 +26,11 @@ r"""Functionality for finding critical points of any scalar function."""
 import warnings
 import numpy as np
 
-from scipy.spatial import cKDTree
+from scipy.spatial import cKDTree, KDTree
+from scipy.spatial.distance import cdist
 
 from chemtools.topology.point import CriticalPoint
+from chemtools.topology.ode import bond_paths_rk45
 
 
 class Topology(object):
@@ -75,6 +77,15 @@ class Topology(object):
         self._neighbours = self._polyhedron_coordinates(n_neighbours)
         # dictionary for storing critical points using (rank, signature) as key
         self._cps = {}
+        # dictionary for storing bond paths of each bond-critical point using the index
+        #  of critical point as key and the items are the list: [ndarray(M_1, 3), ndarray(M_2, 3)]
+        #  signifying the two different bond paths.
+        self._bp = {}
+
+    @property
+    def bp(self):
+        """Dictionary of bond paths for each bond-critical point. Keys are indices of `bcp`."""
+        return self._bp
 
     @property
     def cps(self):
@@ -194,3 +205,268 @@ class Topology(object):
         else:
             raise NotImplementedError("Number of vertices {} is not supported".format(n_vertices))
         return coords
+
+    def newton_step(self, pts, alpha=1.0, use_log=False):
+        def grad_func_log(dens_vals, grad_vals):
+            return grad_vals / dens_vals[:, None]
+
+        def hess_func_log(dens_vals, grad_vals, hess_vals):
+            grad_mat = np.einsum("ni,nj->nij", grad_vals, grad_vals)
+            return hess_vals / dens_vals[:, None, None] - grad_mat / dens_vals[:, None, None] ** 2.0
+
+        dens = self.func(pts)
+        grad = self.grad(pts)
+        hess = self.hess(pts)
+        if use_log:
+            grad_log = grad_func_log(dens, grad)
+            hess_log = hess_func_log(dens, grad, hess)
+            solution = np.linalg.solve(hess_log, grad_log)
+        else:
+            solution = np.linalg.solve(hess, grad)
+
+        return pts - alpha[:, None] * solution, np.linalg.norm(grad, axis=1), hess
+
+    def find_critical_points_vectorized(
+        self,
+        atom_coords,
+        xtol=1e-8,
+        ftol=1e-8,
+        ss_rad=0.1,
+        # u_bnd_rad=1.5,
+        init_norm_cutoff=0.5,
+        dens_cutoff=1e-5,
+        decimal_uniq=12,
+        rad_uniq=0.01,
+        use_log=False,
+        verbose=False
+    ):
+        r"""
+        Find and store the critical points with a vectorization approach.
+
+        Parameters
+        ----------
+        atom_coords: ndarray(M, 3)
+            Atomic coordinates, used to construct atomic grids over each center as
+            initial points.
+        xtol: float, optional
+            Point converges if the difference between two iterations is less than `xtol`
+            in all three dimensions. Also needs to satisfy `ftol` convergence.
+        ftol: float, optional
+            Point converges if the norm of the gradient is less than `ftol`. Also needs
+            to satisfy `xtol` convergence.
+        ss_rad: float, optional
+            Points that are 2`ss_rad` away from the atomic coordinates are included as
+            initial guesses.
+        init_norm_cutoff: float, optional
+            Points whose gradient norm is less than `init_norm_cutoff` are excluded when
+            constructing the initial atomic grid.
+        dens_cutoff: float, optional
+            If the point diverges during the critical point finding process then it excludes it
+            based on its density value being less than `dens_cutoff`.
+        decimal_uniq: float, optional
+            Rounds each critical point to this `decimal_uniq` decimal place. Used to condense points
+            together that are close together.
+        rad_uniq: float, optional
+            Points that are `rad_uniq` apart, are grouped together and the one with the smallest
+            gradient norm is picked. Used to condense points together that are close together
+        use_log: float, optional
+            If true, then uses the logarithm of the electorn density. Speeds-up convergence.
+        verbose: float, optional
+            If true, then prints the sum of the norm of the gradient per iteration and number of
+            points that didn't converge.
+
+        Warns
+        -----
+        RuntimeWarning
+            - Poincare-Hopf equation isn't satisfied. This implies not all critical points were
+              found.
+            - The norm of the gradient of the final crtical points are not less than 1e-5.
+
+        Notes
+        -----
+        - Newton-Ralphson equation is used to find the roots of the gradient.
+
+        - The algorithm is as follows:
+            1. Constructs an atomic grid over each atomic center.
+            2. Points that are close to center and that have small gradients are
+                included to be initial guesses. Points whose density values is small are not.
+            3. While-loop is done until each point from the initial guess converged.
+            4. Points whose density values are too small are removed from the iteration process.
+            5. Points that are identical are merged together by first rounding to some decimal
+               places and then a KDTree is used to group the points into small balls and the
+               points with the smallest gradient are picked out of each ball.
+
+        """
+        # Construct set of points around each center
+        # from grid.onedgrid import OneDGrid
+        # from grid.atomgrid import AtomGrid
+        # natoms = len(atom_coords)
+        # atom_grids_list = []
+        # rad_grid = np.arange(0.0, u_bnd_rad, ss_rad)
+        # rgrid = OneDGrid(points=rad_grid, weights=np.empty(rad_grid.shape))
+        # for i in range(natoms):
+        #     atomic_grid = AtomGrid.from_preset(10, preset="fine", rgrid=rgrid, center=atom_coords[i])
+        #     atom_grids_list.append(atomic_grid.points)
+        # pts = np.vstack(atom_grids_list)
+
+        # Use density to remove points greater than certain value (0.001 au)
+        cut_off = self.func(self._points) > dens_cutoff
+        pts = self._points[cut_off, :]
+
+        # Include points that have small gradients and close to the centers
+        close_centers = np.any(cdist(pts, atom_coords) < 2 * ss_rad, axis=1)
+        norm_grad = np.linalg.norm(self.grad(pts), axis=1)
+        pts_decis = close_centers | (norm_grad < init_norm_cutoff)
+        pts = pts[pts_decis]
+        norm_grad = norm_grad[pts_decis]
+
+        if verbose:
+            print(f"Start Critical Points Finding.")
+            print(f"Number of initial points: {len(pts)}")
+
+        # Solve critical-point finding via Newton-Ralpson with backtracing
+        # Keep going until all points converge
+        p1, p0, grad_norm0 = np.ones(pts.shape) * 1000.0, pts, norm_grad
+        alpha = np.ones(len(p1))  # Initial Step-Sizes
+        converged_pts = np.empty((0, 3), dtype=float)
+        niter = 0
+
+        while len(p1) != 0:
+            # Take Newton-Ralphson Step
+            p1, grad_norm1, hess = self.newton_step(p0, alpha=alpha, use_log=use_log)
+
+            if verbose:
+                print(f"Iteration: {niter + 1},   "
+                      f"Sum Gradient Norm of pts left: {(np.sum(grad_norm1))}   "
+                      f"Number of pts left: {len(p1)}")
+            # TODO: Add Armijo condition
+
+            # Remove points whose density is very small and gradient
+            dens1 = self.func(p1)
+            include = (dens1 > dens_cutoff)
+            p1 = p1[include, :]
+            p0 = p0[include, :]
+            alpha = alpha[include]
+            grad_norm1 = grad_norm1[include]
+
+            # Store points that converge in its 3 dimensions
+            err = np.abs(p1 - p0)
+            did_converge = np.all(err < xtol, axis=1) & (grad_norm1 < ftol)
+            converged_pts = np.vstack((converged_pts, p1[did_converge, :]))
+
+            # Remove points that did converge
+            didnt_converge = np.bitwise_not(did_converge)
+            p1 = p1[didnt_converge, :]
+            alpha = alpha[didnt_converge]
+            grad_norm1 = grad_norm1[didnt_converge]
+
+            # Update variables for next iteration
+            p0 = p1
+            niter += 1
+
+        # Round to `decimal_uniq` decimal place and remove any non-unique points.
+        test, indices = np.unique(
+            np.round(converged_pts, decimals=decimal_uniq),
+            axis=0,
+            return_index=True
+        )
+        converged_pts = test[np.argsort(indices)]
+        print(converged_pts)
+
+        # Get final gradients
+        final_gradients = np.linalg.norm(self.grad(converged_pts), axis=1)
+
+        # See if any duplicates were found then run the kdtree algorithm
+        dist = cdist(converged_pts, converged_pts)
+        dist[np.diag_indices(len(converged_pts))] = 1.0
+        maxim = np.any(dist < rad_uniq, axis=1)
+        if np.any(maxim):
+            indices = set(range(len(converged_pts)))
+            tree = KDTree(converged_pts)
+            indices_include = []
+            while len(indices) != 0:
+                index = indices.pop()
+                query = tree.query_ball_point(converged_pts[index], r=rad_uniq)
+                gradient_ball = final_gradients[query]
+                sort_indices = np.argsort(gradient_ball)
+                indices_include.append(query[sort_indices[0]])  # Pick the point with smallest gradient
+                indices = indices.difference(query)
+
+            final_gradients = final_gradients[indices_include]
+            converged_pts = converged_pts[indices_include]
+
+        if verbose:
+            print(f"Final number of points found {len(converged_pts)}")
+        print(final_gradients)
+        # Check the gradient are all small
+        if np.any(final_gradients > 1e-5):
+            warnings.warn("Gradient of the final critical points are not all smaller than 1e-5.",
+                          RuntimeWarning)
+
+        # compute rank & signature of critical point
+        hess = self.hess(converged_pts)
+        eigs, evecs = np.linalg.eigh(hess)
+        for i in range(len(converged_pts)):
+            cp = CriticalPoint(converged_pts[i], eigs[i], evecs[i], 1e-4)
+            self._cps.setdefault((cp.rank[0], cp.signature[0]), []).append(cp)
+
+        # check Poincare–Hopf equation
+        if not self.poincare_hopf_equation:
+            warnings.warn("Poincare–Hopf equation is not satisfied.", RuntimeWarning)
+
+    def find_bond_paths(self, eps_dir=1e-4, tol=1e-14, ss_0=1e-8, max_ss=0.01, maxiter=2000):
+        r"""
+        Find bond paths of each bond critical point.
+
+        The critical points must be found first.
+        RungeRunge-Kutta of order 4(5) with adaptive step-size is used to solve for
+        bond path.
+
+        Parameters
+        ----------
+        eps_dir : float, optional
+            The displacement in the direction in the eigenvector of the Hessian at the bond
+            critical point.
+        tol : float, optional
+            Tolerance for the adaptive step-size.
+        ss_0 : float, optional
+            The initial step-size of the ODE (RK45) solver.
+        max_ss : float, optional
+            Maximum step-size of the ODE (RK45) solver.
+        maxiter : int, optional
+            The maximum number of iterations of taking a step in the ODE solver.
+
+        """
+        if not self._cps:
+            raise RuntimeError(f"Dictionary empty, critical points should be found first.")
+        if eps_dir < 0.0:
+            raise ValueError(f"eps_dir {eps_dir} must be positive.")
+
+        all_pts = []
+        for i, cp in enumerate(self.bcp):
+            coordinate = cp.coordinate
+            eigs = cp.eigenvalues
+            evecs = cp._eigenvectors
+            if np.any(eigs[0] < -1e-8):
+                bond_path_dir = evecs[:, eigs[0] > 0.0].T
+
+                for b in bond_path_dir:
+                    dir1 = coordinate + eps_dir * b
+                    dir2 = coordinate - eps_dir * b
+                    all_pts.append(dir1)
+                    all_pts.append(dir2)
+        all_pts = np.array(all_pts)
+        bond_paths = bond_paths_rk45(
+            all_pts,
+            self.func,
+            self.grad,
+            ss_0=ss_0,
+            max_ss=max_ss,
+            tol=tol,
+            maxiter=maxiter
+        )
+
+        count = 0
+        for i_cp in range(len(self.bcp)):
+            self._bp[i_cp] = [np.array(bond_paths[count]), np.array(bond_paths[count + 1])]
+            count += 2

--- a/chemtools/topology/critical.py
+++ b/chemtools/topology/critical.py
@@ -287,12 +287,11 @@ class Topology(object):
         - Newton-Ralphson equation is used to find the roots of the gradient.
 
         - The algorithm is as follows:
-            1. Constructs an atomic grid over each atomic center.
-            2. Points that are close to center and that have small gradients are
+            1. Points that are close to center and that have small gradients are
                 included to be initial guesses. Points whose density values is small are not.
-            3. While-loop is done until each point from the initial guess converged.
-            4. Points whose density values are too small are removed from the iteration process.
-            5. Points that are identical are merged together by first rounding to some decimal
+            2. While-loop is done until each point from the initial guess converged.
+            3. Points whose density values are too small are removed from the iteration process.
+            4. Points that are identical are merged together by first rounding to some decimal
                places and then a KDTree is used to group the points into small balls and the
                points with the smallest gradient are picked out of each ball.
 
@@ -371,7 +370,6 @@ class Topology(object):
             return_index=True
         )
         converged_pts = test[np.argsort(indices)]
-        print(converged_pts)
 
         # Get final gradients
         final_gradients = np.linalg.norm(self.grad(converged_pts), axis=1)
@@ -397,7 +395,7 @@ class Topology(object):
 
         if verbose:
             print(f"Final number of points found {len(converged_pts)}")
-        print(final_gradients)
+
         # Check the gradient are all small
         if np.any(final_gradients > 1e-5):
             warnings.warn("Gradient of the final critical points are not all smaller than 1e-5.",

--- a/chemtools/topology/critical.py
+++ b/chemtools/topology/critical.py
@@ -424,6 +424,7 @@ class Topology(object):
         pts = self._points[cut_off, :]
 
         # Include points that have small gradients and close to the centers provided
+        #  Useful in cases where loads of naive points are provided
         norm_grad = np.linalg.norm(self.grad(pts), axis=1)
         if include_centers is not None:
             close_centers = np.any(cdist(pts, include_centers) < 2 * ss_rad, axis=1)

--- a/chemtools/topology/ode.py
+++ b/chemtools/topology/ode.py
@@ -1,0 +1,211 @@
+# -*- coding: utf-8 -*-
+# ChemTools is a collection of interpretive chemical tools for
+# analyzing outputs of the quantum chemistry calculations.
+#
+# Copyright (C) 2016-2019 The ChemTools Development Team
+#
+# This file is part of ChemTools.
+#
+# ChemTools is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# ChemTools is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+#
+# --
+import numpy as np
+
+__all__ = [
+    "bond_paths_rk45",
+]
+
+
+def _get_normalized_gradient_func(grad_func):
+    r"""Returns the normalized version of the function."""
+    def norm_grad_func(x):
+        gradient = grad_func(x)
+        return gradient / np.linalg.norm(gradient, axis=1)[:, None]
+    return norm_grad_func
+
+
+def _RK45_step(pts, grad_func, step_size, grad0=None):
+    r"""
+    Runge-Kutta fourth and five-order step for the following ode system:
+
+    .. math::
+        \frac{d(r(s))}{ds} = \nabla \rho (r(s)),
+
+    where :math:`\nabla \rho(x)` is the gradient of a function.
+
+    Parameters
+    ----------
+    pts : ndarray(M, 3)
+        Points to take a step in.
+    grad_func: callable(ndarray(M,3), ndarray(M,3))
+        Callable function that takes in points and obtains the gradient.
+    step_size: float
+        Stepsize for the step
+    grad0: ndarray(M, 3)
+        If the gradient is already computed on `pts`, then avoids re-computing it.
+
+    Returns
+    -------
+    (ndarray(M,3), ndarray(M,3)):
+        Returns fourth-order and fifth-order Runge-Kutta step, respectively.
+
+    """
+    # Fourth and Fifth-Order Runge-Kutta
+    if grad0 is None:
+        k1 = step_size * grad_func(pts)
+    else:
+        k1 = step_size * grad0
+    k2 = step_size * grad_func(pts + 0.4 * k1)
+    k3 = step_size * grad_func(pts + (3.0 / 32) * k1 + (9.0 / 32.0) * k2)
+    k4 = step_size * grad_func(pts + (1932 / 2197) * k1 - (7200 / 2197) * k2 + (7296 / 2197) * k3)
+    k5 = step_size * grad_func(
+        pts + (439 / 216) * k1 - 8.0 * k2 + (3680 / 513) * k3 - (845 / 4104) * k4
+    )
+    k6 = step_size * grad_func(
+        pts
+        - (8.0 / 27.0) * k1
+        + 2.0 * k2
+        - (3544 / 2565) * k3
+        + (1859 / 4104) * k4
+        - (11 / 40) * k5
+    )
+
+    # Get the fourth and five-order approximation
+    y_four = pts + (25.0 / 216.0) * k1 + (1408 / 2565) * k3 + (2197 / 4101) * k4 - k5 / 5.0
+    y_five = (
+        pts +
+        (16.0 / 135.0) * k1
+        + (6656 / 12825) * k3
+        + (28561 / 56430) * k4
+        - (9.0 / 50.0) * k5
+        + (2.0 / 55.0) * k6
+    )
+    return y_four, y_five
+
+
+def bond_paths_rk45(
+    initial_pts,
+    dens_func,
+    grad_func,
+    ss_0=1e-7,
+    tol=1e-7,
+    max_ss=0.25,
+    tol_conv=1e-10,
+    maxiter=2000
+):
+    r"""
+    Solves the following problem ODE using Runge-Kutta of order 4(5) with adaptive step-size
+
+    .. math::
+        \frac{d(r(t))}{dt} = \frac{\nabla \rho(r(t))}{|| \rho(r() ||}
+
+    over a set of points.
+
+    Parameters
+    ----------
+    initial_pts: ndarray(N, 3)
+        Initial points to solve for steepest-ascent/backtracing.
+    dens_func: callable(ndarray(N,3), ndarray(N))
+        The electron density function.
+    grad_func: callable(ndarray(N,3), ndarray(N,3))
+        The gradient of the electron density.
+    beta_spheres: ndarray(M,)
+        The beta-sphere/trust-region radius of each atom. These are spheres
+        centered at each maxima that reduces the convergence of each point.
+    maximas: ndarray(M,3)
+        The position of each atoms in the molecule.
+    ss_0: float, optional
+        The initial step-size of the ODE (RK45) solver.
+    max_ss: float, optional
+        Maximum step-size of the ODE (RK45) solver.
+    tol_conv: float, optional
+        Tolerance for the convergence of a point from a ODE step.
+    tol: float, optional
+        Tolerance for the adaptive step-size.
+    maxiter: int, optional
+        The maximum number of iterations of taking a step in the ODE solver.
+    terminate_if_other_basin_found : bool
+        If true, then if multiple basin values were found, then the ODE solver will exit.
+        If false, then the ODE solver will run until all points enter one of the
+        beta-sphere/trust-region.
+
+    Returns
+    -------
+    ndarray(N,):
+        Integer array that assigns each point to a basin/maxima/atom of the molecule.
+        If value is negative one, then the point wasn't assigned to a basin.
+
+    """
+    norm_grad_func = _get_normalized_gradient_func(grad_func)
+
+    numb_pts = initial_pts.shape[0]
+    if isinstance(ss_0, float):
+        ss = np.ones((numb_pts, 1)) * ss_0
+    elif isinstance(ss_0, np.ndarray):
+        if not ss_0.shape[1] == 1:
+            raise ValueError(f"Steps-size {ss_0.shape} should have shape of the form (N, 1).")
+        ss = ss_0.copy()
+    else:
+        raise TypeError(f"Step-size ss_0 {type(ss_0)} should have type float or array.")
+
+    pts = initial_pts.copy()
+    dens_vals0 = dens_func(initial_pts)
+
+    not_found_indices = np.arange(numb_pts)
+    niter = 0  # Number of iterations
+    grad0 = norm_grad_func(pts)  # Avoids re-computing the gradient twice, used to check for NNA
+    pts_curr = pts.copy()
+    gradient_paths = [[] for _ in range(len(pts_curr))]
+    while len(not_found_indices) != 0:
+        if niter == maxiter:
+            raise RuntimeError(
+                f"Number of iterations reached maximum {niter}, "
+                f"this may be because of a non-nuclear attractor (NNA) which may cause the ODE "
+                f"to cycle between two points. Repeat this calculation by including the "
+                f"non-nuclear attractor to the list of critical points."
+            )
+        y_four, y_five = _RK45_step(pts_curr, norm_grad_func, ss, grad0)
+
+        # Update step-size
+        ss = (tol * ss / (2.0 * np.linalg.norm(y_five - y_four, axis=1)[:, None])) ** 0.25
+        ss[ss > max_ss] = max_ss
+
+        # Get density values and if the density-values decreased, reduce step-size
+        dens_vals1 = dens_func(y_five)
+        indices = np.where(dens_vals1 <= dens_vals0)[0]
+        if len(indices) != 0:
+            y_five[indices, :] = pts_curr[indices, :]
+            ss[indices] *= 0.25
+
+        for i, global_index_pt in enumerate(not_found_indices):
+            if i not in indices:
+                gradient_paths[global_index_pt].append(y_five[i])
+
+        # Check any points are within the beta-spheres and remove them if they converged.
+        converged = np.where(np.all(np.abs(y_five - pts_curr) < tol_conv, axis=1))[0]
+        if len(converged) != 0:
+            not_found_indices = np.delete(not_found_indices, converged)
+            y_five = np.delete(y_five, converged, axis=0)
+            ss = np.delete(ss, converged)[:, None]
+            dens_vals1 = np.delete(dens_vals1, converged)
+
+        if len(y_five) == 0:
+            break
+        # Update next iteration
+        grad0 = norm_grad_func(y_five)
+        pts_curr = y_five.copy()
+        dens_vals0 = dens_vals1
+        niter += 1
+
+    return gradient_paths

--- a/chemtools/topology/point.py
+++ b/chemtools/topology/point.py
@@ -170,3 +170,8 @@ class CriticalPoint(EigenValueTool):
     def coordinate(self):
         """Cartesian coordinate of critical point."""
         return self._coord
+
+    @property
+    def eigenvectors(self):
+        """Eigenvectors of the critical point."""
+        return self._eigenvectors

--- a/chemtools/topology/test/test_critical.py
+++ b/chemtools/topology/test/test_critical.py
@@ -81,7 +81,7 @@ def test_bond_paths_terminate_at_maxima(fchk, numb_bcp):
     # Test the termination point is an atomic coordinate
     for i in range(0, numb_bcp):
         for j in range(0, 2):
-            bond_path1 = result.bp[j][0][-1, :]
+            bond_path1 = result.bp[i][j][-1, :]
             dist = np.linalg.norm(bond_path1 - mol.coordinates, axis=1)
             assert np.any(dist < 0.1)
 


### PR DESCRIPTION
## Description

- Added my own approach of finding critical points that is significantly faster than the current method.
- Added an option to use the logarithm of the density and (hence gradient and hessian) when finding critical points using the Newton-Ralphson equation. This should increase speed of convergence since it becomes quadratic near the centers
- Added finding bond paths (using vectorization approach) 
- Added ode.py with Runge-Kutta 4(5) with adaptive step-size and added bond-path finding.
- Added tests for critical points and bond paths which weren't there before.

The critical points algorithm is as follows:
            1. Points that are close to center and that have small gradients are
                included to be initial guesses. Points whose density values is small are not.
            2. While-loop is done until each point from the initial guess converges to a critical point using Newton-Ralphson (Armijo backtracing is not used).
            3. Points whose density values are too small are removed from the iteration process.
            4. When the while-loop is finished. Points that are identical are merged together by first rounding to some decimal
               places and then a KDTree is used to group the points into small balls and the
               points with the smallest gradient are picked out of each ball.
- The poincare-Hopf equation is checked, if not then a warning is raised.
- If any of the gradients are smaller than 1e-5, then a warning is raised.

The API follows the previous critical point finder:
```python
mol = Molecule.from_file(file_path)
centers = mol.coordinates

# Generate points
pts = MolecularGrid.from_molecule(mol).points

# Construct Topology Objectt
result = Topology(
    mol.compute_density,
    mol.compute_gradient,
    mol.compute_hessian,
    pts
 )
result.find_critical_points_vectorized(centers, verbose=False)
result.find_bond_paths(max_ss=1e-3)
```

## Examples

It takes four seconds (with ChemtoolsCUDA) to find critical points of dipeptide ALA_ALA (23 atoms) and 20 seconds for PHE_TRP (53 atoms and def2-SPVD basis-set) It took 5 seconds to find the bond paths and note the bcp and rcp found between pi-teeing (T-shaped) side-chains :

![dipeptide_critical_points](https://github.com/theochem/chemtools/assets/10901502/490f2c83-b262-4e3e-9bdb-d8bf93a27eeb)


Here is 2014 GPU [implementation](https://onlinelibrary.wiley.com/doi/10.1002/jcc.23752) of other people code (with basis-set 6-31++G(2p,2d) ). Note that our method seems to be significantly faster than theirs)
![Screenshot from 2024-03-06 12-11-46](https://github.com/theochem/chemtools/assets/10901502/d31aa81d-85a4-4251-b0bf-8d89442b9c6c)


Here is a bond-path version 
  
![bond_paths_c4h8](https://github.com/theochem/chemtools/assets/10901502/c8de4da2-10a7-4d65-a93b-3f2b067d529e)



## Type of Changes
Please remove the lines that don't represent the type of your PR.

 :sparkles: New Feature
