### PR TITLE
Fix #57: Add energy validation for ORCA output files

### DIFF
--- a/chemtools/toolbox/test/test_utils.py
+++ b/chemtools/toolbox/test/test_utils.py
@@ -110,6 +110,15 @@ def test_get_dict_energy_raises():
     assert_raises(ValueError, get_dict_energy, molecule)
 
 
+def test_get_dict_energy_none_energy_raises():
+    """Test that get_dict_energy raises ValueError when energy is None."""
+    with path('chemtools.data', 'ch4_uhf_ccpvdz.fchk') as fname:
+        molecule = Molecule.from_file(fname)
+        # Simulate a molecule without energy (like ORCA files)
+        molecule._iodata.energy = None
+        assert_raises(ValueError, get_dict_energy, molecule)
+
+
 def test_get_dict_density_raises():
     # check molecule
     with path('chemtools.data', 'ch4_uhf_ccpvdz.fchk') as file1:

--- a/chemtools/toolbox/utils.py
+++ b/chemtools/toolbox/utils.py
@@ -208,8 +208,12 @@ def get_dict_energy(molecule):
             # validate that energy is available
             if mol.energy is None:
                 raise ValueError(
-                    "Molecule with {0} electrons does not contain total energy. "
-                    "This is common for ORCA output files (*.wfn, *.mkl).".format(nelec)
+                    (
+                        "Molecule with {0} electrons does not contain total energy. "
+                        "This is common for ORCA output files (*.wfn, *.mkl). "
+                        "Please use a file format that includes energy (e.g., *.fchk) "
+                        "or ensure each Molecule/IOData instance has its energy set."
+                    ).format(nelec)
                 )
             # store number of electrons and energy in a dictionary
             energies[nelec] = mol.energy

--- a/chemtools/toolbox/utils.py
+++ b/chemtools/toolbox/utils.py
@@ -185,6 +185,14 @@ def get_dict_energy(molecule):
         # get homo/lumo energy
         homo_e, lumo_e, _, _ = get_homo_lumo_data(molecule)
         nelec = sum(molecule.mo.nelectrons)
+        # validate that energy is available
+        if molecule.energy is None:
+            raise ValueError(
+                "Molecule does not contain total energy information. "
+                "This is common for ORCA output files (*.wfn, *.mkl). "
+                "Please use a file format that includes energy (e.g., *.fchk) "
+                "or provide multiple molecule files with explicit energy values."
+            )
         # store number of electron and energy in a dictionary
         energies = {nelec: molecule.energy,
                     nelec + 1: molecule.energy + lumo_e,
@@ -197,6 +205,12 @@ def get_dict_energy(molecule):
             nelec = sum(mol.mo.nelectrons)
             if nelec in list(energies.keys()):
                 raise ValueError("Two molecules have {0} electrons!".format(nelec))
+            # validate that energy is available
+            if mol.energy is None:
+                raise ValueError(
+                    "Molecule with {0} electrons does not contain total energy. "
+                    "This is common for ORCA output files (*.wfn, *.mkl).".format(nelec)
+                )
             # store number of electrons and energy in a dictionary
             energies[nelec] = mol.energy
     else:


### PR DESCRIPTION
### Fix ORCA file handling error in `CondensedConceptualDFT.from_file()`

This PR fixes **#57**, where ORCA-generated `.wfn` and `.mkl` files caused a runtime crash when loaded using `CondensedConceptualDFT.from_file()`.

#### Issue

ORCA output files do not include total energy information. However, `get_dict_energy()` assumed `molecule.energy` was always present, leading to the following error:

```
TypeError: unsupported operand type(s) for +: 'NoneType' and 'float'
```

#### Solution

* Added explicit validation in `get_dict_energy()` to check whether `molecule.energy` is `None`
* Raises a clear and user-friendly `ValueError` explaining the limitation
* Guides users to prefer `.fchk` files or alternative conversion workflows
* Added a dedicated test case to cover this scenario

#### Changes

* **`chemtools/toolbox/utils.py`**: Added energy availability validation
* **`chemtools/toolbox/test/test_utils.py`**: Added regression test for missing energy data

#### Testing

* Syntax and static checks passed
* Full test suite requires the optional `horton` dependency
